### PR TITLE
Changes to suppress Rails3 warning

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,5 @@
+=[FIXED] Moved contents of rails/init.rb into init.rb to avoid Rails 3 deprecation warnings.
+
 = Resource Controller
 
 resource_controller makes RESTful controllers easier, more maintainable, and super readable.  With the RESTful controller pattern hidden away, you can focus on what makes your controller special.

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,8 @@
-require File.dirname(__FILE__)+'/rails/init.rb'
+require 'resource_controller'
+
+ActionController::Base.class_eval do
+  include Urligence
+  helper_method :smart_url
+  
+  extend ResourceController::ActionControllerExtension
+end

--- a/lib/resource_controller.rb
+++ b/lib/resource_controller.rb
@@ -23,4 +23,4 @@ module ResourceController
   end
 end
 
-require File.dirname(__FILE__)+'/../rails/init.rb' unless ActionController::Base.include?(Urligence)
+require File.dirname(__FILE__)+'/../init.rb' unless ActionController::Base.include?(Urligence)

--- a/rails/init.rb
+++ b/rails/init.rb
@@ -1,6 +1,0 @@
-ActionController::Base.class_eval do
-  include Urligence
-  helper_method :smart_url
-  
-  extend ResourceController::ActionControllerExtension
-end

--- a/resource_controller.gemspec
+++ b/resource_controller.gemspec
@@ -65,7 +65,6 @@ Gem::Specification.new do |s|
      "lib/resource_controller/response_collector.rb",
      "lib/resource_controller/singleton.rb",
      "lib/urligence.rb",
-     "rails/init.rb",
      "test/Rakefile",
      "test/app/controllers/accounts_controller.rb",
      "test/app/controllers/application_controller.rb",


### PR DESCRIPTION
Moved contents of rails/init.rb into init.rb to avoid Rails 3 deprecation warnings.
